### PR TITLE
Warning Cleanup, Model layer injection refactor

### DIFF
--- a/Hazard_Model.UnitTests/Core/Mocks/MockGame.cs
+++ b/Hazard_Model.UnitTests/Core/Mocks/MockGame.cs
@@ -22,12 +22,14 @@ public class MockGame : IGame
             new MockPlayer(0, Cards.CardFactory, Values, Board, new LoggerStubT<MockPlayer>()),
             new MockPlayer(1, Cards.CardFactory, Values, Board, new LoggerStubT<MockPlayer>())
         ];
-        Regulator.Initialize(this);
+        State = new StateMachine(Players.Count, new LoggerStubT<StateMachine>());
+        Regulator = new MockRegulator(new LoggerStubT<MockRegulator>(), this);
+        Regulator.Initialize();
     }
 
     public Microsoft.Extensions.Logging.ILogger<MockGame> Logger { get => _logger; }
     public IBoard Board { get; set; } = new MockBoard();
-    public IRegulator Regulator { get; set; } = new MockRegulator(new LoggerStubT<MockRegulator>());
+    public IRegulator Regulator { get; set; } 
     public IRuleValues Values { get; set; } = new MockRuleValues();
     public Guid ID { get; set; }
     public bool DefaultCardMode { get; set; } = true;

--- a/Hazard_Model.UnitTests/Core/Mocks/MockRegulator.cs
+++ b/Hazard_Model.UnitTests/Core/Mocks/MockRegulator.cs
@@ -1,15 +1,16 @@
-﻿using Hazard_Share.Enums;
+﻿using Hazard_Model.Core;
+using Hazard_Share.Enums;
 using Hazard_Share.Interfaces.Model;
 using Hazard_Share.Services.Serializer;
 using Microsoft.Extensions.Logging;
 
 namespace Hazard_Model.Tests.Core.Mocks;
 
-public class MockRegulator(ILogger logger) : IRegulator
+public class MockRegulator(ILogger logger, MockGame currentGame) : IRegulator
 {
-    private MockGame? _currentGame = null;
-    private ILogger _logger = logger;
-    private int _numPlayers = 0;
+    private MockGame _currentGame = currentGame;
+    private readonly ILogger _logger = logger;
+    private int _numPlayers = currentGame.Players.Count;
     private int _actionsCounter = 3;
     private int _prevActionCount = 4;
     public int CurrentActionsLimit { get; set; } = 5;
@@ -84,12 +85,8 @@ public class MockRegulator(ILogger logger) : IRegulator
         throw new NotImplementedException();
     }
 
-    public void Initialize(IGame game)
+    public void Initialize()
     {
-        _currentGame = (MockGame)game;
-        _logger = ((MockGame)game).Logger;
-        _numPlayers = _currentGame.Players.Count;
-
         CurrentActionsLimit = _currentGame.Values.SetupActionsPerPlayers[_numPlayers];
 
         if (_currentGame?.State?.CurrentPhase == GamePhase.TwoPlayerSetup) {

--- a/Hazard_Model.UnitTests/DataAccess/BinarySerializerTests.cs
+++ b/Hazard_Model.UnitTests/DataAccess/BinarySerializerTests.cs
@@ -14,7 +14,7 @@ public class BinarySerializerTests
 {
     private readonly MockGame _toSerialGame = new();
     private readonly MockGame _deserialGame = new();
-    private string _testFileName;
+    private string _testFileName = string.Empty;
 
     public BinarySerializerTests()
     {
@@ -157,7 +157,9 @@ public class BinarySerializerTests
                     Assert.AreEqual(_toSerialGame.Cards.Sets[i].Cards[j].IsTradeable, _deserialGame.Cards.Sets[i].Cards[j].IsTradeable);
                     Assert.IsNotNull(_toSerialGame.Cards.Sets[i].Cards[j].CardSet);
                     Assert.IsNotNull(_deserialGame.Cards.Sets[i].Cards[j].CardSet);
+#pragma warning disable CS8602 // for some reason the compiler doesn't recognize that the previous two null checks should affect this next Assert.
                     Assert.AreEqual(_toSerialGame.Cards.Sets[i].Cards[j].CardSet.Name, _deserialGame.Cards.Sets[i].Cards[j].CardSet.Name);
+#pragma warning restore CS8602
                     Assert.AreEqual(_toSerialGame.Cards.Sets[i].Cards[j].Target[0], _deserialGame.Cards.Sets[i].Cards[j].Target[0]); // could test the entire array but the default Targets are always length 1
                 }
                 Assert.AreEqual(_toSerialGame.Cards.Sets[i].ForcesTrade, _deserialGame!.Cards.Sets[i].ForcesTrade);
@@ -177,7 +179,9 @@ public class BinarySerializerTests
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.Library[j].IsTradeable, _deserialGame.Cards.GameDeck.Library[j].IsTradeable);
                 Assert.IsNotNull(_toSerialGame.Cards.GameDeck.Library[j].CardSet);
                 Assert.IsNotNull(_deserialGame.Cards.GameDeck.Library[j].CardSet);
+#pragma warning disable CS8602 // for some reason the compiler doesn't recognize that the previous two null checks should affect this next Assert.
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.Library[j].CardSet.Name, _deserialGame.Cards.GameDeck.Library[j].CardSet.Name);
+#pragma warning restore CS8602
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.Library[j].Target[0], _deserialGame.Cards.GameDeck.Library[j].Target[0]); // could test the entire array but the default Targets are always length 1
             }
             Assert.IsNotNull(_toSerialGame.Cards.GameDeck.DiscardPile);
@@ -190,7 +194,9 @@ public class BinarySerializerTests
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.DiscardPile[j].IsTradeable, _deserialGame.Cards.GameDeck.DiscardPile[j].IsTradeable);
                 Assert.IsNotNull(_toSerialGame.Cards.GameDeck.DiscardPile[j].CardSet);
                 Assert.IsNotNull(_deserialGame.Cards.GameDeck.DiscardPile[j].CardSet);
+#pragma warning disable CS8602 // for some reason the compiler doesn't recognize that the previous two null checks should affect this next Assert.
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.DiscardPile[j].CardSet.Name, _deserialGame.Cards.GameDeck.DiscardPile[j].CardSet.Name);
+#pragma warning restore CS8602
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.DiscardPile[j].Target[0], _deserialGame.Cards.GameDeck.DiscardPile[j].Target[0]); // could test the entire array but the default Targets are always length 1
             }
         }
@@ -228,8 +234,7 @@ public class BinarySerializerTests
         rewardCard.FillTestValues();
         _toSerialGame.Regulator.Reward = rewardCard;
         _toSerialGame.Regulator.CurrentActionsLimit = 7;
-
-        _deserialGame.Regulator.Initialize(_deserialGame);
+        _deserialGame.Regulator.Initialize();
 
         await BinarySerializer.Save([_toSerialGame.Regulator], _testFileName, true);
 
@@ -299,7 +304,7 @@ public class BinarySerializerTests
         });
 
         _deserialGame.Players.Clear();
-        _deserialGame.Regulator.Initialize(_deserialGame);
+        _deserialGame.Regulator.Initialize();
         _deserialGame.Cards.Wipe();
         #endregion
 
@@ -372,7 +377,9 @@ public class BinarySerializerTests
                     Assert.AreEqual(_toSerialGame.Cards.Sets[i].Cards[j].IsTradeable, _deserialGame.Cards.Sets[i].Cards[j].IsTradeable);
                     Assert.IsNotNull(_toSerialGame.Cards.Sets[i].Cards[j].CardSet);
                     Assert.IsNotNull(_deserialGame.Cards.Sets[i].Cards[j].CardSet);
+#pragma warning disable CS8602 // for some reason the compiler doesn't recognize that the previous two null checks should affect this next Assert.
                     Assert.AreEqual(_toSerialGame.Cards.Sets[i].Cards[j].CardSet.Name, _deserialGame.Cards.Sets[i].Cards[j].CardSet.Name);
+#pragma warning restore CS8602
                     Assert.AreEqual(_toSerialGame.Cards.Sets[i].Cards[j].Target[0], _deserialGame.Cards.Sets[i].Cards[j].Target[0]); // could test the entire array but the default Targets are always length 1
                 }
                 Assert.AreEqual(_toSerialGame.Cards.Sets[i].ForcesTrade, _deserialGame!.Cards.Sets[i].ForcesTrade);
@@ -392,7 +399,9 @@ public class BinarySerializerTests
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.Library[j].IsTradeable, _deserialGame.Cards.GameDeck.Library[j].IsTradeable);
                 Assert.IsNotNull(_toSerialGame.Cards.GameDeck.Library[j].CardSet);
                 Assert.IsNotNull(_deserialGame.Cards.GameDeck.Library[j].CardSet);
+#pragma warning disable CS8602 // for some reason the compiler doesn't recognize that the previous two null checks should affect this next Assert.
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.Library[j].CardSet.Name, _deserialGame.Cards.GameDeck.Library[j].CardSet.Name);
+#pragma warning restore CS8602
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.Library[j].Target[0], _deserialGame.Cards.GameDeck.Library[j].Target[0]); // could test the entire array but the default Targets are always length 1
             }
             Assert.IsNotNull(_toSerialGame.Cards.GameDeck.DiscardPile);
@@ -405,7 +414,9 @@ public class BinarySerializerTests
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.DiscardPile[j].IsTradeable, _deserialGame.Cards.GameDeck.DiscardPile[j].IsTradeable);
                 Assert.IsNotNull(_toSerialGame.Cards.GameDeck.DiscardPile[j].CardSet);
                 Assert.IsNotNull(_deserialGame.Cards.GameDeck.DiscardPile[j].CardSet);
+#pragma warning disable CS8602 // for some reason the compiler doesn't recognize that the previous two null checks should affect this next Assert.
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.DiscardPile[j].CardSet.Name, _deserialGame.Cards.GameDeck.DiscardPile[j].CardSet.Name);
+#pragma warning restore CS8602
                 Assert.AreEqual(_toSerialGame.Cards.GameDeck.DiscardPile[j].Target[0], _deserialGame.Cards.GameDeck.DiscardPile[j].Target[0]); // could test the entire array but the default Targets are always length 1
             }
             #endregion

--- a/Hazard_Model/Core/StateMachine.cs
+++ b/Hazard_Model/Core/StateMachine.cs
@@ -15,7 +15,6 @@ public class StateMachine : IBinarySerializable
     private bool _phaseStageTwo = false;
     private int _playerTurn = 0;
     private int _round = 0;
-    private readonly int _numPlayers = 0;
     private int _numTrades = 0;
 
     /// <summary>
@@ -33,21 +32,22 @@ public class StateMachine : IBinarySerializable
     /// <exception cref="StateMachine(int)">Thrown when the number of players given is not 2-6.</exception>
     public StateMachine(int numPlayers, ILogger<StateMachine> logger)
     {
-        _numPlayers = numPlayers;
+        NumPlayers = numPlayers;
         _logger = logger;
 
-        if (_numPlayers == 2)
+        if (NumPlayers == 2)
             CurrentPhase = GamePhase.TwoPlayerSetup;
-        else if (_numPlayers > 2 && _numPlayers < 7)
+        else if (NumPlayers > 2 && NumPlayers < 7)
             CurrentPhase = GamePhase.DefaultSetup;
         else
             CurrentPhase = GamePhase.Null;
 
-        IsActivePlayer = new(_numPlayers);
+        IsActivePlayer = new(NumPlayers);
         IsActivePlayer.SetAll(true);
     }
 
     #region Properties
+    public int NumPlayers { get; }
     public BitArray IsActivePlayer { get; private set; }
     /// <summary>
     /// Gets what phase the game is currently in, or sets the phase and invokes <see cref="StateChanged"/>.
@@ -97,7 +97,7 @@ public class StateMachine : IBinarySerializable
     /// <summary>
     /// Gets the number of rounds the game has entered. Or, sets this value and invokes <see cref="StateChanged"/>.
     /// </summary>
-    /// <remarks>A round is completed once <see cref="PlayerTurn"/> increases beyond <see cref="_numPlayers"/>. The 0th Round is the setup round.</remarks>
+    /// <remarks>A round is completed once <see cref="PlayerTurn"/> increases beyond <see cref="NumPlayers"/>. The 0th Round is the setup round.</remarks>
     /// <value>
     /// An integer representing the number of times the turn has passed to each player.
     /// </value>
@@ -192,7 +192,7 @@ public class StateMachine : IBinarySerializable
     public void IncrementPlayerTurn()
     {
         if (CurrentPhase.Equals(GamePhase.DefaultSetup) || CurrentPhase.Equals(GamePhase.TwoPlayerSetup)) {
-            if (PlayerTurn >= _numPlayers)
+            if (PlayerTurn >= NumPlayers)
                 PlayerTurn = 0;
             else {
                 int firstActive = NextActivePlayer();
@@ -202,7 +202,7 @@ public class StateMachine : IBinarySerializable
                     throw new Exception("No Active Player Remaining!");
             }
         }
-        else if (PlayerTurn >= _numPlayers) {
+        else if (PlayerTurn >= NumPlayers) {
             IncrementRound();
         }
         else {
@@ -254,13 +254,13 @@ public class StateMachine : IBinarySerializable
     /// <param name="player"></param>
     public void DisablePlayer(int player)
     {
-        if (player >= 0 && player < _numPlayers)
+        if (player >= 0 && player < NumPlayers)
             IsActivePlayer[player] = false;
     }
     private int NextActivePlayer() // begins checking at PlayerTurn + 1, looping to beginning if at the end of the Player list
     {
         int start;
-        if (PlayerTurn == _numPlayers - 1)
+        if (PlayerTurn == NumPlayers - 1)
             start = 0;
         else
             start = PlayerTurn + 1;
@@ -272,7 +272,7 @@ public class StateMachine : IBinarySerializable
             else
                 index++;
 
-            if (index > _numPlayers - 1)
+            if (index > NumPlayers - 1)
                 index = 0;
 
         } while (index != start);
@@ -281,7 +281,7 @@ public class StateMachine : IBinarySerializable
     }
     private int NextActivePlayer(int start) // begins checking at a specified player number, *inclusive*
     {
-        if (start >= 0 && start < _numPlayers) {
+        if (start >= 0 && start < NumPlayers) {
             int index = start;
             do {
                 if (IsActivePlayer[index])
@@ -289,7 +289,7 @@ public class StateMachine : IBinarySerializable
                 else
                     index++;
 
-                if (index > _numPlayers - 1)
+                if (index > NumPlayers - 1)
                     index = 0;
 
             } while (index != start);

--- a/Hazard_Model/DataAccess/AssetFetcher.cs
+++ b/Hazard_Model/DataAccess/AssetFetcher.cs
@@ -1,4 +1,5 @@
-﻿using Hazard_Share.Interfaces.Model;
+﻿using Hazard_Model.Assets;
+using Hazard_Share.Interfaces.Model;
 
 namespace Hazard_Model.DataAccess;
 /// <summary>
@@ -51,5 +52,9 @@ public class AssetFetcher(IAssetFactory factory) : IAssetFetcher
             return cardSets;
         else
             return null;
+    }
+    public IRuleValues FetchRuleValues()
+    {
+        return new RuleValues();
     }
 }

--- a/Hazard_Share/Hazard_Share.projitems
+++ b/Hazard_Share/Hazard_Share.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\Model\IBinarySerializable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\Model\ICardSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\Model\ICardSetData.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interfaces\ViewModel\IGameService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Registry\RegistryRelationEnum.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Enums\TerrID.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\Model\IAssetFactory.cs" />

--- a/Hazard_Share/Interfaces/Model/IAssetFetcher.cs
+++ b/Hazard_Share/Interfaces/Model/IAssetFetcher.cs
@@ -10,4 +10,5 @@ public interface IAssetFetcher
     /// </summary>
     /// <returns>An array of ready <see cref="ICard"/> instances for use by a <see cref="Hazard_Model.Entities.Deck"/>, if data retrieval is successful. If not, <c>null</c>.</returns>
     List<ICardSet>? FetchCardSets();
+    IRuleValues FetchRuleValues();
 }

--- a/Hazard_Share/Interfaces/Model/IGame.cs
+++ b/Hazard_Share/Interfaces/Model/IGame.cs
@@ -41,12 +41,12 @@ public interface IGame : IBinarySerializable
     /// </value>
     List<IPlayer> Players { get; set; }
     /// <summary>
-    /// Gets or sets the game's state machine, tracking player count and status, turns, etc.
+    /// Gets the game's state machine, tracking player count and status, turns, etc.
     /// </summary>
     /// <value>
     /// An instance of <see cref="StateMachine"/>, or <see langword="null"/> if the game has not been initialized.
     /// </value>
-    StateMachine State { get; set; }
+    StateMachine State { get; }
     /// <summary>
     /// Gets or sets an instance describing the Game board; stores both data and relations between Board objects.
     /// </summary>
@@ -62,12 +62,12 @@ public interface IGame : IBinarySerializable
     /// </value>
     CardBase Cards { get; set; }
     /// <summary>
-    /// Gets or sets a service which "regulates" interaction between the model and the players (interprets player actions according to the game state, then executes logic according to game rules).
+    /// Gets a service which "regulates" interaction between the model and the players (interprets player actions according to the game state, then executes logic according to game rules).
     /// </summary>
     /// <value>
     /// An instance of <see cref="IBoard"/>.
     /// </value>
-    IRegulator Regulator { get; set; }
+    //IRegulator Regulator { get; }
     /// <summary>
     /// Gets or sets a data object containing game-specific rules values, like continent bonuses or equations for bonus armies.
     /// </summary>

--- a/Hazard_Share/Interfaces/Model/IRegulator.cs
+++ b/Hazard_Share/Interfaces/Model/IRegulator.cs
@@ -83,5 +83,5 @@ public interface IRegulator : IBinarySerializable
     /// Initializes this instance with a brand new game.
     /// </summary>
     /// <param name="game">The newly created <see cref="IGame"/>.</param>
-    abstract void Initialize(IGame game);
+    abstract void Initialize();
 }

--- a/Hazard_Share/Interfaces/ViewModel/IGameService.cs
+++ b/Hazard_Share/Interfaces/ViewModel/IGameService.cs
@@ -1,0 +1,9 @@
+﻿using Hazard_Model.Core;
+using Hazard_Share.Interfaces.Model;
+
+namespace Hazard_Share.Interfaces.ViewModel;
+
+public interface IGameService
+{
+   (IGame Game, Regulator Regulator) CreateGameWithRegulator(int numPlayers);
+}

--- a/Hazard_Share/Interfaces/ViewModel/IMainVM.cs
+++ b/Hazard_Share/Interfaces/ViewModel/IMainVM.cs
@@ -9,6 +9,7 @@ namespace Hazard_Share.Interfaces.ViewModel;
 /// </summary>
 public interface IMainVM
 {
+    #region Properties
     /// <summary>
     /// Gets or inits the current <see cref="IGame"/>.
     /// </summary>
@@ -16,7 +17,7 @@ public interface IMainVM
     /// The current <see cref="IGame"/> instance if both it and the <see cref="IMainVM"/> have been initialized; otherwise <see langword="null"/>. <br/>
     /// See <see cref="IGame.Initialize(string[])"/>, <see cref="IGame.Initialize(FileStream)"/>, and <see cref="IMainVM.Initialize(string)"/>, <see cref="IMainVM.Initialize(ValueTuple{string, string}[])"/>.
     /// </value>
-    IGame? CurrentGame { get; init; }
+    IGame? CurrentGame { get; set; }
     /// <summary>
     /// Gets or sets the current game phase.
     /// </summary>
@@ -138,7 +139,9 @@ public interface IMainVM
     /// An <see cref="ICommand"/>.
     /// </value>
     ICommand ChooseTerritoryBonus_Command { get; }
+    #endregion
 
+    #region Events
     /// <summary>
     /// Fires if the turn is changing control between players.
     /// </summary>
@@ -186,16 +189,8 @@ public interface IMainVM
     /// Fires when a player wins.
     /// </summary>
     event EventHandler<int>? PlayerWon;
-    /// <summary>
-    /// Initializes an <see cref="IMainVM"/> using names and color names provided by a user.
-    /// </summary>
-    /// <param name="namesAndColors">An array of <see cref="Tuple{T1, T2}"/>, where T1 is a <see cref=" string"/> player name, and T2 is a <see cref="string">name</see> of their color.</param>
-    abstract void Initialize((string Name, string ColorName)[] namesAndColors);
-    /// <summary>
-    /// Initializes an <see cref="IMainVM"/> from a save file.
-    /// </summary>
-    /// <param name="fileName">The <see cref="string">name</see> of the file from which to initialize.</param>
-    abstract void Initialize(string fileName);
+    #endregion
+    abstract void Initialize(string[] players, string[] colors, string? fileName);
     /// <summary>
     /// Executes logic of the <see cref="NewGame_Command"/>.
     /// </summary>

--- a/Hazard_View/Services/BootStrapper.cs
+++ b/Hazard_View/Services/BootStrapper.cs
@@ -17,7 +17,6 @@ public class BootStrapper(App mainApp, ILogger<BootStrapper> logger) : IBootStra
     {
         var viewModel = _mainApp.AppHost.Services.GetRequiredService<IMainVM>();
         MainWindow mainWindow = new();
-        viewModel.Initialize([(string.Empty, string.Empty)]);
         mainWindow.Initialize(viewModel);
         _mainApp.MainWindow = mainWindow;
         _mainApp.MainWindow.Show();
@@ -42,13 +41,15 @@ public class BootStrapper(App mainApp, ILogger<BootStrapper> logger) : IBootStra
 
             var viewModel = _mainApp.AppHost.Services.GetRequiredService<IMainVM>();
             _logger.LogInformation("Initializing game from source: {FileName}.", fileName);
-            viewModel.Initialize(fileName);
+            viewModel.Initialize([], [], fileName);
             ((MainWindow)_mainApp.MainWindow).Initialize(viewModel);
             _mainApp.MainWindow.Show();
         }
     }
     public void InitializeGame((string Name, string Color)[] namesAndColors)
     {
+        var playerNames = namesAndColors.Select(item => item.Name).ToArray();
+        var playerColors = namesAndColors.Select(item => item.Color).ToArray();
         SaveFileName = string.Empty;
 
         MainWindow mainWindow = new();
@@ -63,7 +64,7 @@ public class BootStrapper(App mainApp, ILogger<BootStrapper> logger) : IBootStra
         }
 
         var viewModel = _mainApp.AppHost.Services.GetRequiredService<IMainVM>();
-        viewModel.Initialize(namesAndColors);
+        viewModel.Initialize(playerNames, playerColors, null);
         ((MainWindow)(_mainApp.MainWindow)).Initialize(viewModel);
         _mainApp.MainWindow.Show();
     }

--- a/Hazard_ViewModel/Services/GameService.cs
+++ b/Hazard_ViewModel/Services/GameService.cs
@@ -1,0 +1,37 @@
+﻿using Hazard_Model.Core;
+using Hazard_Model.DataAccess;
+using Hazard_Share.Interfaces.Model;
+using Hazard_Share.Interfaces.ViewModel;
+using Hazard_Share.Services.Registry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hazard_ViewModel.Services;
+
+public class GameService(
+    ILoggerFactory loggerFactory,
+    IAssetFetcher assetFetcher,
+    IAssetFactory assetFactory,
+    ITypeRegister<ITypeRelations> registry,
+    IConfiguration config)
+    : IGameService
+{
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
+    private readonly IAssetFetcher _assetFetcher = assetFetcher;
+    private readonly IAssetFactory _assetFactory = assetFactory;
+    private readonly ITypeRegister<ITypeRelations> _registry = registry;
+    private readonly IConfiguration _config = config;
+
+    public (IGame Game, Regulator Regulator) CreateGameWithRegulator(int numPlayers)
+    {
+        var game = new Game(numPlayers, _loggerFactory, _assetFetcher, _registry, _config);
+        Regulator regulator = new Regulator(_loggerFactory.CreateLogger<Regulator>(), game);
+        regulator.Initialize();
+        return (game, regulator);
+    }
+}


### PR DESCRIPTION
Some cleanup with null checks led to recognizing problems in how the Model layer (the Game simulation) was initialized. Changes to how the MainVM is injected with the Game simulation (now in two parts, IGame and Regulator) allowed for more ordered initialization and removes the need for null checking at several points.